### PR TITLE
Stop singleton provider from recreating objects implementing __len__

### DIFF
--- a/rodi/__init__.py
+++ b/rodi/__init__.py
@@ -396,7 +396,7 @@ class SingletonTypeProvider:
         self._instance = None
 
     def __call__(self, context, parent_type):
-        if not self._instance:
+        if self._instance is None:
             self._instance = (
                 self._type(*[fn(context, self._type) for fn in self._args_callbacks])
                 if self._args_callbacks


### PR DESCRIPTION
Hello Roberto! A tiny bugfix if you please.

Right now the singleton provider checks if the singleton instance already present using `if not self._instance` check. This doesn't work well with objects implementing Sized protocol. Python calls `__len__` on such objects to check it for truthyness, and if the call returns 0, the condition evaluates to `True` - even if the instance was already created earlier.

I fixed it simply to compare against `None`.