### PR TITLE
fix: singleton reinstantiated if registered at last & fix: initialized class attribute being overridden 

### DIFF
--- a/rodi/__init__.py
+++ b/rodi/__init__.py
@@ -1159,7 +1159,8 @@ class Container(ContainerProtocol):
                     # assert _type not in context.resolved, "_map keys must be unique"
                     # check if its in the map
                     if _type in _map:
-                        # NB: do not call resolver if one was already prepared for the type
+                        # NB: do not call resolver if one was already prepared for the
+                        # type
                         raise OverridingServiceException(_type, resolver)
                     else:
                         resolved = context.resolved[_type]

--- a/rodi/__init__.py
+++ b/rodi/__init__.py
@@ -572,11 +572,12 @@ class DynamicResolver:
         """
         Returns a value indicating whether a class attribute should be ignored for
         dependency resolution, by name and value.
+        It's ignored if it's a ClassVar or if it's already initialized explicitly.
         """
-        try:
-            return value.__origin__ is ClassVar
-        except AttributeError:
-            return False
+        is_classvar = getattr(value, "__origin__", None) is ClassVar
+        is_initialized = getattr(self.concrete_type, key, None) is not None
+
+        return is_classvar or is_initialized
 
     def _resolve_by_annotations(
         self, context: ResolutionContext, annotations: Dict[str, Type]

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -12,6 +12,11 @@ sys.path.append("./examples")
 
 @pytest.mark.parametrize("file_path", examples)
 def test_example(file_path: str):
-    module_name = file_path.replace("./examples/", "").replace(".py", "")
+    module_name = (
+        # Windows
+        file_path.replace("./examples\\", "")
+        # Unix
+        .replace("./examples/", "").replace(".py", "")
+    )
     # assertions are in imported modules
     importlib.import_module(module_name)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -2591,3 +2591,40 @@ def test_singleton_register_order_first():
 
     # check that singletons are always the same instance
     assert bar.foo is bar2.foo is foo
+
+
+def test_ignore_class_variable_if_already_initialized():
+    """
+    if a class variable is already initialized, it should not be overridden by
+    resolving a new instance nor fail if rodi can't resolve it.
+    """
+
+    foo_instance = Foo()
+
+    class A:
+        foo: Foo = foo_instance
+
+    class B:
+        example: ClassVar[str] = "example"
+        dependency: A
+
+    container = Container()
+
+    container.register(A)
+    container.register(B)
+    container._add_exact_singleton(Foo)
+
+    b = container.resolve(B)
+    a = container.resolve(A)
+    foo = container.resolve(Foo)
+
+    assert isinstance(a, A)
+    assert isinstance(a.foo, Foo)
+    assert foo_instance is a.foo
+
+    assert isinstance(b, B)
+    assert b.example == "example"
+    assert b.dependency.foo is foo_instance
+
+    # check that is not being overridden by resolving a new instance
+    assert foo is not a.foo

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -2539,3 +2539,55 @@ def test_ignore_subclass_class_var():
     a = container.resolve(A)
 
     assert a.foo == "foo"
+
+
+def test_singleton_register_order_last():
+    """
+    The registration order of singletons should not matter.
+    Check that singletons are not registered twice when they are registered
+    after their dependents.
+    """
+
+    class Bar:
+        foo: Foo
+
+    class Bar2:
+        foo: Foo
+
+    container = Container()
+    container.register(Bar)
+    container.register(Bar2)
+    container._add_exact_singleton(Foo)
+
+    bar = container.resolve(Bar)
+    bar2 = container.resolve(Bar2)
+    foo = container.resolve(Foo)
+
+    # check that singletons are always the same instance
+    assert bar.foo is bar2.foo is foo
+
+
+def test_singleton_register_order_first():
+    """
+    The registration order of singletons should not matter.
+    Check that singletons are not registered twice when they are registered
+    before their dependents.
+    """
+
+    class Bar:
+        foo: Foo
+
+    class Bar2:
+        foo: Foo
+
+    container = Container()
+    container._add_exact_singleton(Foo)
+    container.register(Bar)
+    container.register(Bar2)
+
+    bar = container.resolve(Bar)
+    bar2 = container.resolve(Bar2)
+    foo = container.resolve(Foo)
+
+    # check that singletons are always the same instance
+    assert bar.foo is bar2.foo is foo


### PR DESCRIPTION
Hi there, I made these two corrections that you may be interested in. 

- **singleton being reinstantiated if registered after its dependent**
  Right now, if we register a singleton dependency **after** registering it dependant, it will instanciate the singleton multiple 
  times.
  With this change, I'm basically making the following test pass (it wouldn't pass with current release):

  ```python
  class Bar:
      foo: Foo
  
  class Qux:
      foo: Foo
  
  container = Container()
  container.register(Bar)
  container.register(Qux)
  
  # we register the dependency AFTER already registered its dependents
  container._add_exact_singleton(Foo)
  
  bar = container.resolve(Bar)
  qux = container.resolve(Qux)
  foo = container.resolve(Foo)
  
  # check that singletons are always the same instance
  # the following line goes 💥 right now, and it has been fixed by this PR
  assert bar.foo is qux.foo is foo 
  ```
  
- **initialized class attribute being overridden**
  If we declare a class attribute and **initialize it** inside the class, rodi should not override it or even try to resolve it (IMO).
  This is already being taken care of when the class attribute is annotated with `ClassVar`, but I think that the same logic
  should apply if the attribute already has a value at resolving time, in other words, if the user already resolved it for us.
  
  ```python
  foo_instance = Foo()
  
  class A:
    # we explicitly initialize foo already
    foo: Foo = foo_instance
  
  container.register(A)
  container._add_exact_singleton(Foo)
  
  # right now, if Foo were not in the container
  # it would fail right here trying to resolve A
  a = container.resolve(A)
  
  foo = container.resolve(Foo)
  
  assert isinstance(a.foo, Foo)
  
  # right now, if Foo is in the container, the next line would fail
  # because rodi has overridden a.foo for a new instance
  assert foo_instance is a.foo
  assert foo is not a.foo
  ```
  
-------

> **Warning**
> I think the first correction would be a nice addition and it shouldn't be a breaking change.
> The second fix, however, could break existing code in case someone was initializing a dependency without noticing. It 
> would be an edge case, but... it could be.

