### PR TITLE
fix: resolve protocols without needing to define init

### DIFF
--- a/rodi/__init__.py
+++ b/rodi/__init__.py
@@ -21,8 +21,9 @@ from typing import (
 )
 
 if sys.version_info >= (3, 9):  # pragma: no cover
-    # Python 3.9
-    from typing import _no_init_or_replace_init
+    from typing import _no_init_or_replace_init as _no_init
+elif sys.version_info >= (3, 8):  # pragma: no cover
+    from typing import _no_init
 
 try:
     from typing import Protocol
@@ -584,12 +585,13 @@ class DynamicResolver:
         return is_classvar or is_initialized
 
     def _has_default_init(self):
-        if self.concrete_type.__init__ is object.__init__:
+        init = getattr(self.concrete_type, "__init__", None)
+
+        if init is object.__init__:
             return True
 
-        if sys.version_info >= (3, 9):  # pragma: no cover
-            # Python 3.9
-            if self.concrete_type.__init__ is _no_init_or_replace_init:
+        if sys.version_info >= (3, 8):  # pragma: no cover
+            if init is _no_init:
                 return True
         return False
 

--- a/rodi/__init__.py
+++ b/rodi/__init__.py
@@ -16,6 +16,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    _no_init_or_replace_init,
     cast,
     get_type_hints,
 )
@@ -605,7 +606,11 @@ class DynamicResolver:
         chain = context.dynamic_chain
         chain.append(concrete_type)
 
-        if getattr(concrete_type, "__init__") is object.__init__:
+        if getattr(concrete_type, "__init__") in [
+            object.__init__,
+            # for protocols that doesn't defile its own init:
+            _no_init_or_replace_init,
+        ]:
             annotations = get_type_hints(
                 concrete_type,
                 vars(sys.modules[concrete_type.__module__]),


### PR DESCRIPTION
When implementing a `Protocol` without defining its own `__init__` method, a generic initialization method is generated autmatically (`typing._no_init_or_replace_init`). This PR checks if the class being resolved has that specific `__init__` on it, and if it does, makes rodi behave the same way it does for normal classes when its __init__ is `object.__init__`

Closes: #45 
Ref: #31 