### PR TITLE
ContainerProtocol.register returns self

### DIFF
--- a/rodi/__init__.py
+++ b/rodi/__init__.py
@@ -31,6 +31,11 @@ try:
 except ImportError:  # pragma: no cover
     from typing_extensions import Protocol
 
+try:
+    from typing import Self
+except ImportError:  # pragma: no cover
+    from typing_extensions import Self
+
 
 T = TypeVar("T")
 
@@ -41,7 +46,7 @@ class ContainerProtocol(Protocol):
     and tell if a type is configured.
     """
 
-    def register(self, obj_type: Union[Type, str], *args, **kwargs):
+    def register(self, obj_type: Union[Type, str], *args, **kwargs) -> Self:
         """Registers a type in the container, with optional arguments."""
 
     def resolve(self, obj_type: Union[Type[T], str], *args, **kwargs) -> T:


### PR DESCRIPTION
Y'all may have a reason for not defining the return type of `ContainerProtocol.register`, but if so, I didn't pick up on it.

Here I propose making `ContainerProtocol.register` return `Self`. This matches what `Container.register` does and allows a chaining of registrations of like

```python
container.register(...).register(...).register(...)
```

Honestly, I don't care and am equally happy with `None`, but a tighter bound than `Any` seems beneficial to maintaining portability across container implementations.