### PR TITLE
Improve typing of `inject`

### DIFF
--- a/rodi/__init__.py
+++ b/rodi/__init__.py
@@ -56,7 +56,10 @@ class ContainerProtocol(Protocol):
 AliasesTypeHint = Dict[str, Type]
 
 
-def inject(globalsns=None, localns=None) -> Callable[..., Any]:
+def inject(
+    globalsns: Optional[Dict[str, Any]] = None, 
+    localns: Optional[Dict[str, Any]] = None,
+) -> Callable[[T], T]:
     """
     Marks a class or a function as injected. This method is only necessary if the class
     uses locals and the user uses Python >= 3.10, to bind the function's locals to the


### PR DESCRIPTION
`globals()` and `locals()` are both returning `dict[str, Any]`:
- https://github.com/python/typeshed/blob/712e4146ef255f14ecf396aac4996cdbef708312/stdlib/builtins.pyi#L1413
- https://github.com/python/typeshed/blob/712e4146ef255f14ecf396aac4996cdbef708312/stdlib/builtins.pyi#L1443

`inject` only add two protected attributes to a function / type. So, we can say that it returns the object unchanged: `T -> T`.