### PR TITLE
Improve `resolve()` typing

### DIFF
--- a/rodi/__init__.py
+++ b/rodi/__init__.py
@@ -18,6 +18,7 @@ from typing import (
     Union,
     cast,
     get_type_hints,
+    overload,
 )
 
 if sys.version_info >= (3, 8):  # pragma: no cover
@@ -41,10 +42,17 @@ class ContainerProtocol(Protocol):
     and tell if a type is configured.
     """
 
-    def register(self, obj_type: Union[Type, str], *args, **kwargs):
+    def register(self, obj_type: Union[Type, str], *args, **kwargs) -> None:
         """Registers a type in the container, with optional arguments."""
 
-    def resolve(self, obj_type: Union[Type[T], str], *args, **kwargs) -> T:
+    @overload
+    def resolve(self, obj_type: Type[T], *args, **kwargs) -> T: ...
+
+    @overload
+    def resolve(self, obj_type: str, *args, **kwargs) -> Any: ...
+
+    @overload
+    def resolve(self, obj_type: Union[Type[T], str], *args, **kwargs) -> Any:
         """Activates an instance of the given type, with optional arguments."""
 
     def __contains__(self, item) -> bool:
@@ -901,13 +909,31 @@ class Container(ContainerProtocol):
             self.add_transient(obj_type, sub_type)
         return self
 
+    @overload
+    def resolve(
+        self,
+        obj_type: Type[T],
+        scope: Any = None,
+        *args,
+        **kwargs,
+    ) -> T: ...
+
+    @overload
+    def resolve(
+        self,
+        obj_type: str,
+        scope: Any = None,
+        *args,
+        **kwargs,
+    ) -> Any: ...
+
     def resolve(
         self,
         obj_type: Union[Type[T], str],
         scope: Any = None,
         *args,
         **kwargs,
-    ) -> T:
+    ) -> Any:
         """
         Resolves a service by type, obtaining an instance of that type.
         """


### PR DESCRIPTION
Using `Union[Type[T], str]` is problematic, because when `str` is passed, mypy infers `T` to be `Never`. Instead, you should use an `overload` with two cases, so inference would be correct:

```python
from typing import Any, TypeVar, Union, Type, overload

T = TypeVar('T')

class My:
    def resolve(  # type: ignore[empty-body]
        self,
        obj_type: Union[Type[T], str],
    ) -> T:
        ...   # in reallity we would return something here
        
reveal_type(My().resolve(int))
# N: Revealed type is "builtins.int"
reveal_type(My().resolve('a'))
# N: Revealed type is "Never"

class Other:
    @overload
    def resolve(self, obj_type: Type[T]) -> T: ...
    @overload
    def resolve(self, obj_type: str) -> Any: ...
    def resolve(self, obj_type: Any) -> Any: ...

reveal_type(Other().resolve(int))
# N: Revealed type is "builtins.int"
reveal_type(Other().resolve('a'))
# N: Revealed type is "Any"
```

Link: https://mypy-play.net/?mypy=latest&python=3.12&gist=97dd0c638b48950199067e8290e5595e&flags=strict

This way users can actually use `Any` type, while `Never` type cannot be used for literally anything.